### PR TITLE
Add Chrome extension for downloading from channel, playlist, and video pages

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -1,5 +1,9 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
 using VideoLibrary;
 using System.Net;
 using System.Runtime.Serialization;
@@ -11,12 +15,101 @@ namespace YouTube_Downloader
     {
         static void Main(string[] args)
         {
-            string channelId = args[0];
-            string downloadPath = args[1];
-
-            foreach (var url in YouTubeProcess.GetMovieUrlsOfChannel(channelId))
+            // CLI モード: チャンネルIDとダウンロードパスの2引数
+            if (args.Length == 2
+                && !args[0].StartsWith("chrome-extension://")
+                && args[0] != "--native-messaging")
             {
-                YouTubeProcess.Download(url.Key, downloadPath);
+                string channelId = args[0];
+                string downloadPath = args[1];
+                foreach (var url in YouTubeProcess.GetMovieUrlsOfChannel(channelId))
+                {
+                    YouTubeProcess.Download(url.Key, downloadPath);
+                }
+                return;
+            }
+
+            // それ以外はネイティブメッセージングモード
+            // （引数なし、--native-messaging、またはChromeが渡すchrome-extension://...）
+            NativeMessagingHost.Run();
+        }
+    }
+
+    public static class NativeMessagingHost
+    {
+        public static void Run()
+        {
+            var stdin = Console.OpenStandardInput();
+            var stdout = Console.OpenStandardOutput();
+
+            while (true)
+            {
+                var lenBuf = new byte[4];
+                if (stdin.Read(lenBuf, 0, 4) < 4) break;
+
+                int len = BitConverter.ToInt32(lenBuf, 0);
+                var msgBuf = new byte[len];
+                int totalRead = 0;
+                while (totalRead < len)
+                    totalRead += stdin.Read(msgBuf, totalRead, len - totalRead);
+
+                var json = Encoding.UTF8.GetString(msgBuf);
+                using var doc = JsonDocument.Parse(json);
+                ProcessRequest(doc.RootElement, stdout);
+            }
+        }
+
+        static void Send(Stream stdout, object obj)
+        {
+            var json = JsonSerializer.Serialize(obj);
+            var bytes = Encoding.UTF8.GetBytes(json);
+            var lenBytes = BitConverter.GetBytes(bytes.Length);
+            lock (stdout)
+            {
+                stdout.Write(lenBytes, 0, 4);
+                stdout.Write(bytes, 0, bytes.Length);
+                stdout.Flush();
+            }
+        }
+
+        static void ProcessRequest(JsonElement req, Stream stdout)
+        {
+            try
+            {
+                var path = req.GetProperty("path").GetString();
+                var urls = req.GetProperty("urls")
+                              .EnumerateArray()
+                              .Select(u => u.GetString())
+                              .ToList();
+
+                int total = urls.Count;
+                int downloaded = 0;
+                int failed = 0;
+
+                foreach (var url in urls)
+                {
+                    string title = url;
+                    try
+                    {
+                        var youTube = YouTube.Default;
+                        var video = youTube.GetVideo(url);
+                        title = video.FullName;
+                        File.WriteAllBytes(Path.Combine(path, video.FullName), video.GetBytes());
+                        downloaded++;
+                    }
+                    catch
+                    {
+                        failed++;
+                    }
+
+                    Send(stdout, new { type = "progress", current = downloaded + failed, total, title });
+                }
+
+                Send(stdout, new { type = "complete", downloaded, failed, total });
+            }
+            catch (Exception ex)
+            {
+                Send(stdout, new { type = "error", message = ex.Message });
             }
         }
     }

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,0 +1,63 @@
+const HOST_NAME = 'com.youtube_downloader';
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (message.action === 'startDownload') {
+    handleDownload(message.urls, message.path);
+    sendResponse({ started: true });
+  }
+  return true;
+});
+
+function handleDownload(urls, path) {
+  let port;
+
+  try {
+    port = chrome.runtime.connectNative(HOST_NAME);
+  } catch (e) {
+    chrome.runtime.sendMessage({
+      action: 'downloadError',
+      error: `ネイティブアプリへの接続に失敗しました: ${e.message}`
+    });
+    return;
+  }
+
+  port.onMessage.addListener((msg) => {
+    switch (msg.type) {
+      case 'progress':
+        chrome.runtime.sendMessage({
+          action: 'progress',
+          current: msg.current,
+          total: msg.total,
+          title: msg.title ?? ''
+        });
+        break;
+      case 'complete':
+        chrome.runtime.sendMessage({
+          action: 'complete',
+          downloaded: msg.downloaded,
+          failed: msg.failed
+        });
+        port.disconnect();
+        break;
+      case 'error':
+        chrome.runtime.sendMessage({
+          action: 'downloadError',
+          error: msg.message
+        });
+        port.disconnect();
+        break;
+    }
+  });
+
+  port.onDisconnect.addListener(() => {
+    const err = chrome.runtime.lastError;
+    if (err) {
+      chrome.runtime.sendMessage({
+        action: 'downloadError',
+        error: err.message
+      });
+    }
+  });
+
+  port.postMessage({ type: 'download', urls, path });
+}

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -1,0 +1,16 @@
+{
+  "manifest_version": 3,
+  "name": "YouTube Downloader",
+  "version": "1.0",
+  "description": "YouTubeチャンネル・再生リストの動画をダウンロードします",
+  "permissions": ["activeTab", "nativeMessaging", "storage"],
+  "host_permissions": [
+    "https://www.googleapis.com/*"
+  ],
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "background": {
+    "service_worker": "background.js"
+  }
+}

--- a/chrome-extension/native-host-manifest.json
+++ b/chrome-extension/native-host-manifest.json
@@ -1,0 +1,9 @@
+{
+  "name": "com.youtube_downloader",
+  "description": "YouTube Downloader Native Host",
+  "path": "PLACEHOLDER_EXE_PATH",
+  "type": "stdio",
+  "allowed_origins": [
+    "chrome-extension://PLACEHOLDER_EXTENSION_ID/"
+  ]
+}

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <title>YouTube Downloader</title>
+  <style>
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: 'Segoe UI', sans-serif;
+      width: 340px;
+      padding: 16px;
+      background: #fff;
+      color: #333;
+    }
+    h2 {
+      font-size: 16px;
+      color: #c00;
+      margin-bottom: 12px;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    .info-box {
+      background: #f5f5f5;
+      border-left: 3px solid #c00;
+      border-radius: 2px;
+      padding: 8px 12px;
+      margin-bottom: 14px;
+    }
+    .info-box .label {
+      font-size: 10px;
+      color: #888;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+    }
+    .info-box .value {
+      font-size: 13px;
+      font-weight: 600;
+      margin-top: 2px;
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
+    }
+    label {
+      display: block;
+      font-size: 11px;
+      color: #666;
+      margin-bottom: 4px;
+    }
+    input[type="text"],
+    input[type="number"] {
+      width: 100%;
+      padding: 7px 9px;
+      border: 1px solid #ccc;
+      border-radius: 4px;
+      font-size: 13px;
+      margin-bottom: 10px;
+      transition: border-color 0.15s;
+    }
+    input:focus {
+      outline: none;
+      border-color: #c00;
+    }
+    button#download-btn {
+      width: 100%;
+      padding: 9px;
+      background: #c00;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      font-size: 14px;
+      font-weight: 600;
+      cursor: pointer;
+      transition: background 0.15s;
+    }
+    button#download-btn:hover:not(:disabled) { background: #a00; }
+    button#download-btn:disabled { background: #bbb; cursor: not-allowed; }
+    #status {
+      margin-top: 10px;
+      font-size: 12px;
+      color: #555;
+      min-height: 18px;
+      line-height: 1.4;
+    }
+    #status.error { color: #c00; }
+    #status.success { color: #080; }
+    .progress-wrap {
+      display: none;
+      margin-top: 8px;
+      background: #eee;
+      border-radius: 3px;
+      height: 6px;
+      overflow: hidden;
+    }
+    #progress-fill {
+      height: 100%;
+      background: #c00;
+      width: 0%;
+      transition: width 0.3s;
+    }
+    details {
+      margin-top: 14px;
+      border-top: 1px solid #eee;
+      padding-top: 12px;
+    }
+    summary {
+      cursor: pointer;
+      font-size: 11px;
+      color: #999;
+      user-select: none;
+      list-style: none;
+    }
+    summary::before { content: '▶ '; }
+    details[open] summary::before { content: '▼ '; }
+    .settings-body { margin-top: 10px; }
+    button.secondary {
+      width: 100%;
+      padding: 7px;
+      background: #666;
+      color: #fff;
+      border: none;
+      border-radius: 4px;
+      font-size: 12px;
+      cursor: pointer;
+    }
+    button.secondary:hover { background: #444; }
+    #not-supported {
+      font-size: 13px;
+      color: #c00;
+      line-height: 1.6;
+    }
+  </style>
+</head>
+<body>
+  <h2>&#9654; YouTube Downloader</h2>
+
+  <div id="not-supported" style="display:none">
+    YouTubeのチャンネルまたは再生リストのページで開いてください。
+  </div>
+
+  <div id="main-form" style="display:none">
+    <div class="info-box">
+      <div class="label" id="page-type-label"></div>
+      <div class="value" id="page-name">取得中...</div>
+    </div>
+
+    <div id="count-field">
+      <label for="count">ダウンロード数（空欄 = すべて）</label>
+      <input type="number" id="count" min="1" placeholder="すべて">
+    </div>
+
+    <label for="path">保存先フォルダ</label>
+    <input type="text" id="path" placeholder="例: C:\Users\ユーザー名\Downloads">
+
+    <button id="download-btn" disabled>ダウンロード開始</button>
+
+    <div id="status"></div>
+    <div class="progress-wrap" id="progress-wrap">
+      <div id="progress-fill"></div>
+    </div>
+  </div>
+
+  <details>
+    <summary>設定（APIキー）</summary>
+    <div class="settings-body">
+      <label for="api-key">YouTube Data API v3 キー</label>
+      <input type="text" id="api-key" placeholder="AIza...">
+      <button class="secondary" id="save-settings-btn">保存</button>
+    </div>
+  </details>
+
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -1,0 +1,225 @@
+const API_BASE = 'https://www.googleapis.com/youtube/v3';
+
+let pageInfo = null;
+
+document.addEventListener('DOMContentLoaded', async () => {
+  const stored = await chrome.storage.sync.get(['apiKey', 'downloadPath']);
+  if (stored.apiKey) document.getElementById('api-key').value = stored.apiKey;
+  if (stored.downloadPath) document.getElementById('path').value = stored.downloadPath;
+
+  document.getElementById('save-settings-btn').addEventListener('click', saveSettings);
+  document.getElementById('download-btn').addEventListener('click', onDownloadClick);
+
+  const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
+  let url;
+  try { url = new URL(tab.url); } catch { showNotSupported(); return; }
+
+  const parsed = parseYouTubeUrl(url);
+  if (!parsed) { showNotSupported(); return; }
+
+  document.getElementById('main-form').style.display = 'block';
+
+  const labels = { video: '動画', playlist: '再生リスト', channel: 'チャンネル', channel_handle: 'チャンネル', channel_name: 'チャンネル' };
+  document.getElementById('page-type-label').textContent = labels[parsed.type] ?? 'チャンネル';
+
+  if (parsed.type === 'video') {
+    document.getElementById('count-field').style.display = 'none';
+  }
+
+  await resolvePageInfo(parsed, stored.apiKey);
+});
+
+function parseYouTubeUrl(url) {
+  if (url.hostname !== 'www.youtube.com') return null;
+
+  const videoId = url.searchParams.get('v');
+  if (url.pathname === '/watch' && videoId) {
+    return { type: 'video', id: videoId };
+  }
+
+  const listId = url.searchParams.get('list');
+  if (url.pathname === '/playlist' && listId) {
+    return { type: 'playlist', id: listId };
+  }
+
+  const channelMatch = url.pathname.match(/^\/channel\/(UC[\w-]+)/);
+  if (channelMatch) return { type: 'channel', id: channelMatch[1] };
+
+  const handleMatch = url.pathname.match(/^\/@([\w.-]+)/);
+  if (handleMatch) return { type: 'channel_handle', handle: '@' + handleMatch[1] };
+
+  const customMatch = url.pathname.match(/^\/c\/([\w.-]+)/);
+  if (customMatch) return { type: 'channel_name', name: customMatch[1] };
+
+  return null;
+}
+
+async function resolvePageInfo(parsed, apiKey) {
+  if (!apiKey) {
+    document.getElementById('page-name').textContent = parsed.id || parsed.handle || parsed.name || '（APIキーを設定してください）';
+    if (parsed.type === 'channel_handle' || parsed.type === 'channel_name') {
+      setStatus('チャンネルIDの解決にAPIキーが必要です。設定から入力してください。', true);
+      return;
+    }
+    pageInfo = { type: parsed.type, id: parsed.id };
+    document.getElementById('download-btn').disabled = false;
+    return;
+  }
+
+  try {
+    if (parsed.type === 'video') {
+      const data = await apiGet(`videos?part=snippet&id=${parsed.id}&key=${apiKey}`);
+      pageInfo = {
+        type: 'video',
+        id: parsed.id,
+        name: data.items?.[0]?.snippet?.title || parsed.id
+      };
+    } else if (parsed.type === 'channel_handle') {
+      const data = await apiGet(`channels?part=snippet&forHandle=${parsed.handle}&key=${apiKey}`);
+      if (!data.items?.length) throw new Error('チャンネルが見つかりません');
+      pageInfo = { type: 'channel', id: data.items[0].id, name: data.items[0].snippet.title };
+    } else if (parsed.type === 'channel_name') {
+      const data = await apiGet(`channels?part=snippet&forUsername=${parsed.name}&key=${apiKey}`);
+      if (!data.items?.length) throw new Error('チャンネルが見つかりません');
+      pageInfo = { type: 'channel', id: data.items[0].id, name: data.items[0].snippet.title };
+    } else if (parsed.type === 'channel') {
+      const data = await apiGet(`channels?part=snippet&id=${parsed.id}&key=${apiKey}`);
+      pageInfo = {
+        type: 'channel',
+        id: parsed.id,
+        name: data.items?.[0]?.snippet?.title || parsed.id
+      };
+    } else {
+      const data = await apiGet(`playlists?part=snippet&id=${parsed.id}&key=${apiKey}`);
+      pageInfo = {
+        type: 'playlist',
+        id: parsed.id,
+        name: data.items?.[0]?.snippet?.title || parsed.id
+      };
+    }
+
+    document.getElementById('page-name').textContent = pageInfo.name || pageInfo.id;
+    document.getElementById('download-btn').disabled = false;
+  } catch (e) {
+    document.getElementById('page-name').textContent = parsed.id || '（取得失敗）';
+    setStatus(`エラー: ${e.message}`, true);
+  }
+}
+
+async function apiGet(path) {
+  const res = await fetch(`${API_BASE}/${path}`);
+  const data = await res.json();
+  if (data.error) throw new Error(data.error.message);
+  return data;
+}
+
+async function onDownloadClick() {
+  const path = document.getElementById('path').value.trim();
+  if (!path) { setStatus('保存先フォルダを入力してください。', true); return; }
+  if (!pageInfo) { setStatus('ページ情報を取得できていません。', true); return; }
+
+  await saveSettings();
+  document.getElementById('download-btn').disabled = true;
+
+  let urls;
+
+  if (pageInfo.type === 'video') {
+    urls = [`https://www.youtube.com/watch?v=${pageInfo.id}`];
+    setStatus('ダウンロードを開始します...');
+  } else {
+    const apiKey = document.getElementById('api-key').value.trim();
+    if (!apiKey) { setStatus('設定からAPIキーを入力・保存してください。', true); document.getElementById('download-btn').disabled = false; return; }
+
+    const countStr = document.getElementById('count').value.trim();
+    const count = countStr ? parseInt(countStr, 10) : null;
+
+    setStatus('動画リストを取得中...');
+    try {
+      urls = await fetchVideoUrls(pageInfo, apiKey, count);
+    } catch (e) {
+      setStatus(`エラー: ${e.message}`, true);
+      document.getElementById('download-btn').disabled = false;
+      return;
+    }
+
+    if (urls.length === 0) {
+      setStatus('動画が見つかりませんでした。', true);
+      document.getElementById('download-btn').disabled = false;
+      return;
+    }
+
+    setStatus(`${urls.length}件の動画をダウンロードします...`);
+  }
+
+  chrome.runtime.onMessage.addListener(handleProgress);
+  chrome.runtime.sendMessage({ action: 'startDownload', urls, path });
+}
+
+async function fetchVideoUrls(info, apiKey, count) {
+  let playlistId;
+
+  if (info.type === 'channel') {
+    const data = await apiGet(`channels?part=contentDetails&id=${info.id}&key=${apiKey}`);
+    if (!data.items?.length) throw new Error('チャンネルが見つかりません');
+    playlistId = data.items[0].contentDetails.relatedPlaylists.uploads;
+  } else {
+    playlistId = info.id;
+  }
+
+  const urls = [];
+  let nextPageToken = null;
+
+  do {
+    const maxResults = count ? Math.min(count - urls.length, 50) : 50;
+    let endpoint = `playlistItems?part=snippet&playlistId=${playlistId}&maxResults=${maxResults}&key=${apiKey}`;
+    if (nextPageToken) endpoint += `&pageToken=${nextPageToken}`;
+
+    const data = await apiGet(endpoint);
+
+    for (const item of data.items) {
+      const videoId = item.snippet?.resourceId?.videoId;
+      if (videoId) urls.push(`https://www.youtube.com/watch?v=${videoId}`);
+      if (count && urls.length >= count) break;
+    }
+
+    nextPageToken = (count && urls.length >= count) ? null : data.nextPageToken;
+  } while (nextPageToken);
+
+  return urls;
+}
+
+function handleProgress(message) {
+  if (message.action === 'progress') {
+    const pct = Math.round((message.current / message.total) * 100);
+    document.getElementById('progress-wrap').style.display = 'block';
+    document.getElementById('progress-fill').style.width = pct + '%';
+    const title = message.title ? `「${message.title}」` : '';
+    setStatus(`(${message.current}/${message.total}) ${title} ダウンロード中...`);
+  } else if (message.action === 'complete') {
+    document.getElementById('progress-fill').style.width = '100%';
+    const failNote = message.failed > 0 ? `（失敗 ${message.failed}件）` : '';
+    setStatus(`完了！ ${message.downloaded}件ダウンロードしました${failNote}`, false, true);
+    document.getElementById('download-btn').disabled = false;
+    chrome.runtime.onMessage.removeListener(handleProgress);
+  } else if (message.action === 'downloadError') {
+    setStatus(`エラー: ${message.error}`, true);
+    document.getElementById('download-btn').disabled = false;
+    chrome.runtime.onMessage.removeListener(handleProgress);
+  }
+}
+
+function setStatus(text, isError = false, isSuccess = false) {
+  const el = document.getElementById('status');
+  el.textContent = text;
+  el.className = isError ? 'error' : isSuccess ? 'success' : '';
+}
+
+function showNotSupported() {
+  document.getElementById('not-supported').style.display = 'block';
+}
+
+async function saveSettings() {
+  const apiKey = document.getElementById('api-key').value.trim();
+  const downloadPath = document.getElementById('path').value.trim();
+  await chrome.storage.sync.set({ apiKey, downloadPath });
+}

--- a/chrome-extension/setup/register-host.ps1
+++ b/chrome-extension/setup/register-host.ps1
@@ -1,0 +1,57 @@
+﻿# YouTube Downloader - ネイティブメッセージングホスト登録スクリプト
+#
+# 使い方:
+#   .\register-host.ps1 -ExtensionId <拡張機能のID>
+#
+# 拡張機能のIDは chrome://extensions で「デベロッパーモード」を有効にすると確認できます。
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$ExtensionId,
+
+    [Parameter(Mandatory = $false)]
+    [string]$ExePath = ""
+)
+
+$HostName = "com.youtube_downloader"
+
+# EXEのパスが指定されていなければ自動検出
+if (-not $ExePath) {
+    $repoRoot = Resolve-Path "$PSScriptRoot\..\.."
+    $ExePath = Join-Path $repoRoot "bin\Debug\net9.0\win-x64\YouTube_Downloader.exe"
+    if (-not (Test-Path $ExePath)) {
+        Write-Error "EXEが見つかりません: $ExePath`nビルド後に再実行するか、-ExePath で直接指定してください。"
+        exit 1
+    }
+}
+
+$ExePath = (Resolve-Path $ExePath).Path
+
+# マニフェストの保存先
+$ManifestDir  = "$env:LOCALAPPDATA\YouTubeDownloader"
+$ManifestPath = "$ManifestDir\native-host-manifest.json"
+
+New-Item -ItemType Directory -Force -Path $ManifestDir | Out-Null
+
+$Manifest = [ordered]@{
+    name            = $HostName
+    description     = "YouTube Downloader Native Host"
+    path            = $ExePath
+    type            = "stdio"
+    allowed_origins = @("chrome-extension://$ExtensionId/")
+}
+
+$Manifest | ConvertTo-Json | Set-Content -Path $ManifestPath -Encoding UTF8
+
+# レジストリに登録
+$RegPath = "HKCU:\SOFTWARE\Google\Chrome\NativeMessagingHosts\$HostName"
+New-Item -Force -Path $RegPath | Out-Null
+Set-ItemProperty -Path $RegPath -Name "(Default)" -Value $ManifestPath
+
+Write-Host ""
+Write-Host "セットアップ完了！" -ForegroundColor Green
+Write-Host "  EXE      : $ExePath"
+Write-Host "  マニフェスト: $ManifestPath"
+Write-Host "  レジストリ  : $RegPath"
+Write-Host ""
+Write-Host "Chromeを再起動してから拡張機能を使用してください。" -ForegroundColor Yellow


### PR DESCRIPTION
## 変更内容

### Chrome 拡張機能（新規）
- YouTubeのチャンネル・再生リスト・動画ページで動作するポップアップUI
- ダウンロード数を指定可能（空欄=すべて）、動画ページでは1件固定
- ページタイプを自動検出（/watch, /playlist, /@handle, /channel/, /c/）
- YouTube Data API v3 でチャンネル名・動画タイトルを取得・表示
- ダウンロード進捗をリアルタイム表示（進捗バー）
- APIキー・保存先を chrome.storage.sync に記憶

### C# アプリ（変更）
- ネイティブメッセージングホストモードを追加（NativeMessagingHost クラス）
- Chrome が起動時に渡す chrome-extension://... 引数を正しく処理するよう Main() を修正

### セットアップスクリプト（新規）
- chrome-extension/setup/register-host.ps1: Windows レジストリにホストを登録

## 使い方
1. dotnet build でビルド
2. chrome://extensions でデベロッパーモード ON → chrome-extension/ フォルダを読み込む
3. 表示された拡張機能IDで register-host.ps1 -ExtensionId <ID> を実行
4. Chrome を再起動