### PR TITLE
Keep multi-video downloads running after the Chrome extension popup closes

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -41,6 +41,7 @@ namespace YouTube_Downloader
         {
             var stdin = Console.OpenStandardInput();
             var stdout = Console.OpenStandardOutput();
+            var cancelSource = new System.Threading.CancellationTokenSource();
 
             while (true)
             {
@@ -54,8 +55,36 @@ namespace YouTube_Downloader
                     totalRead += stdin.Read(msgBuf, totalRead, len - totalRead);
 
                 var json = Encoding.UTF8.GetString(msgBuf);
-                using var doc = JsonDocument.Parse(json);
-                ProcessRequest(doc.RootElement, stdout);
+                string type;
+                string path = null;
+                List<string> urls = null;
+
+                using (var doc = JsonDocument.Parse(json))
+                {
+                    var root = doc.RootElement;
+                    type = root.TryGetProperty("type", out var t) ? t.GetString() : "download";
+
+                    if (type == "download")
+                    {
+                        path = root.GetProperty("path").GetString();
+                        urls = root.GetProperty("urls")
+                                   .EnumerateArray()
+                                   .Select(u => u.GetString())
+                                   .ToList();
+                    }
+                }
+
+                if (type == "cancel")
+                {
+                    cancelSource.Cancel();
+                    continue;
+                }
+
+                // 新しいダウンロード要求。実行中のダウンロードは背景スレッドで動かし、
+                // メインループはstdinの読み取り（＝キャンセル要求の受信）を継続できるようにする。
+                cancelSource = new System.Threading.CancellationTokenSource();
+                var token = cancelSource.Token;
+                System.Threading.Tasks.Task.Run(() => ProcessDownload(urls, path, stdout, token));
             }
         }
 
@@ -72,22 +101,22 @@ namespace YouTube_Downloader
             }
         }
 
-        static void ProcessRequest(JsonElement req, Stream stdout)
+        static void ProcessDownload(List<string> urls, string path, Stream stdout, System.Threading.CancellationToken token)
         {
             try
             {
-                var path = req.GetProperty("path").GetString();
-                var urls = req.GetProperty("urls")
-                              .EnumerateArray()
-                              .Select(u => u.GetString())
-                              .ToList();
-
                 int total = urls.Count;
                 int downloaded = 0;
                 int failed = 0;
 
                 foreach (var url in urls)
                 {
+                    if (token.IsCancellationRequested)
+                    {
+                        Send(stdout, new { type = "cancelled", downloaded, failed, total });
+                        return;
+                    }
+
                     string title = url;
                     try
                     {

--- a/chrome-extension/background.js
+++ b/chrome-extension/background.js
@@ -1,63 +1,125 @@
 const HOST_NAME = 'com.youtube_downloader';
+const KEEPALIVE_ALARM = 'dl-keepalive';
+
+let port = null;
+
+let state = {
+  active: false,
+  status: 'idle', // idle | running | complete | error | cancelled
+  current: 0,
+  total: 0,
+  title: '',
+  downloaded: 0,
+  failed: 0,
+  error: null
+};
+
+// アラームが発火すること自体が、ダウンロード中にサービスワーカーが
+// アイドルタイムアウトで終了（＝ネイティブポートが切断されダウンロードが中断）
+// するのを防ぐ。処理内容自体は不要。
+chrome.alarms.onAlarm.addListener(() => {});
 
 chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
   if (message.action === 'startDownload') {
-    handleDownload(message.urls, message.path);
+    startDownload(message.urls, message.path);
     sendResponse({ started: true });
+  } else if (message.action === 'cancelDownload') {
+    cancelDownload();
+    sendResponse({ cancelled: true });
+  } else if (message.action === 'getStatus') {
+    sendResponse(state);
   }
   return true;
 });
 
-function handleDownload(urls, path) {
-  let port;
+function startDownload(urls, path) {
+  if (state.active) return;
+
+  state = {
+    active: true,
+    status: 'running',
+    current: 0,
+    total: urls.length,
+    title: '',
+    downloaded: 0,
+    failed: 0,
+    error: null
+  };
+  broadcast({ action: 'progress', current: 0, total: urls.length, title: '' });
+
+  chrome.alarms.create(KEEPALIVE_ALARM, { periodInMinutes: 0.4 });
 
   try {
     port = chrome.runtime.connectNative(HOST_NAME);
   } catch (e) {
-    chrome.runtime.sendMessage({
-      action: 'downloadError',
-      error: `ネイティブアプリへの接続に失敗しました: ${e.message}`
-    });
+    finishWithError(`ネイティブアプリへの接続に失敗しました: ${e.message}`);
     return;
   }
 
   port.onMessage.addListener((msg) => {
     switch (msg.type) {
       case 'progress':
-        chrome.runtime.sendMessage({
-          action: 'progress',
-          current: msg.current,
-          total: msg.total,
-          title: msg.title ?? ''
-        });
+        state.current = msg.current;
+        state.total = msg.total;
+        state.title = msg.title ?? '';
+        broadcast({ action: 'progress', current: msg.current, total: msg.total, title: state.title });
         break;
       case 'complete':
-        chrome.runtime.sendMessage({
-          action: 'complete',
-          downloaded: msg.downloaded,
-          failed: msg.failed
-        });
-        port.disconnect();
+        state.active = false;
+        state.status = 'complete';
+        state.downloaded = msg.downloaded;
+        state.failed = msg.failed;
+        broadcast({ action: 'complete', downloaded: msg.downloaded, failed: msg.failed });
+        cleanup();
+        break;
+      case 'cancelled':
+        state.active = false;
+        state.status = 'cancelled';
+        state.downloaded = msg.downloaded;
+        state.failed = msg.failed;
+        broadcast({ action: 'cancelled', downloaded: msg.downloaded, failed: msg.failed });
+        cleanup();
         break;
       case 'error':
-        chrome.runtime.sendMessage({
-          action: 'downloadError',
-          error: msg.message
-        });
-        port.disconnect();
+        finishWithError(msg.message);
         break;
     }
   });
 
   port.onDisconnect.addListener(() => {
+    if (!state.active) return;
     const err = chrome.runtime.lastError;
-    if (err) {
-      chrome.runtime.sendMessage({
-        action: 'downloadError',
-        error: err.message
-      });
-    }
+    finishWithError(err ? err.message : '接続が切断されました。');
   });
 
   port.postMessage({ type: 'download', urls, path });
+}
+
+function cancelDownload() {
+  if (!state.active || !port) return;
+  port.postMessage({ type: 'cancel' });
+}
+
+function finishWithError(message) {
+  state.active = false;
+  state.status = 'error';
+  state.error = message;
+  broadcast({ action: 'downloadError', error: message });
+  cleanup();
+}
+
+function cleanup() {
+  chrome.alarms.clear(KEEPALIVE_ALARM);
+  if (port) {
+    try { port.disconnect(); } catch { /* already gone */ }
+    port = null;
+  }
+}
+
+function broadcast(message) {
+  chrome.runtime.sendMessage(message).catch(() => {
+    // ポップアップが閉じていて受信側がいない場合は無視して構わない。
+    // 状態自体はstateに保持されており、次にポップアップを開いたときに
+    // getStatusで復元される。
+  });
 }

--- a/chrome-extension/manifest.json
+++ b/chrome-extension/manifest.json
@@ -3,7 +3,7 @@
   "name": "YouTube Downloader",
   "version": "1.0",
   "description": "YouTubeチャンネル・再生リストの動画をダウンロードします",
-  "permissions": ["activeTab", "nativeMessaging", "storage"],
+  "permissions": ["activeTab", "nativeMessaging", "storage", "alarms"],
   "host_permissions": [
     "https://www.googleapis.com/*"
   ],

--- a/chrome-extension/popup.html
+++ b/chrome-extension/popup.html
@@ -124,6 +124,20 @@
       cursor: pointer;
     }
     button.secondary:hover { background: #444; }
+    #cancel-btn {
+      display: none;
+      width: 100%;
+      padding: 7px;
+      margin-top: 8px;
+      background: #fff;
+      color: #c00;
+      border: 1px solid #c00;
+      border-radius: 4px;
+      font-size: 12px;
+      cursor: pointer;
+    }
+    #cancel-btn:hover:not(:disabled) { background: #fdecec; }
+    #cancel-btn:disabled { color: #bbb; border-color: #bbb; cursor: not-allowed; }
     #not-supported {
       font-size: 13px;
       color: #c00;
@@ -158,6 +172,7 @@
     <div class="progress-wrap" id="progress-wrap">
       <div id="progress-fill"></div>
     </div>
+    <button id="cancel-btn">キャンセル</button>
   </div>
 
   <details>

--- a/chrome-extension/popup.js
+++ b/chrome-extension/popup.js
@@ -9,6 +9,8 @@ document.addEventListener('DOMContentLoaded', async () => {
 
   document.getElementById('save-settings-btn').addEventListener('click', saveSettings);
   document.getElementById('download-btn').addEventListener('click', onDownloadClick);
+  document.getElementById('cancel-btn').addEventListener('click', onCancelClick);
+  chrome.runtime.onMessage.addListener(handleProgress);
 
   const [tab] = await chrome.tabs.query({ active: true, currentWindow: true });
   let url;
@@ -27,6 +29,15 @@ document.addEventListener('DOMContentLoaded', async () => {
   }
 
   await resolvePageInfo(parsed, stored.apiKey);
+
+  // 既に進行中のダウンロードがあれば（ポップアップを閉じて再度開いた場合など）、
+  // 状態をバックグラウンドから復元してUIに反映する。
+  const status = await chrome.runtime.sendMessage({ action: 'getStatus' });
+  if (status?.active) {
+    document.getElementById('download-btn').disabled = true;
+    showCancelButton();
+    updateProgressUi(status.current, status.total, status.title);
+  }
 });
 
 function parseYouTubeUrl(url) {
@@ -151,8 +162,32 @@ async function onDownloadClick() {
     setStatus(`${urls.length}件の動画をダウンロードします...`);
   }
 
-  chrome.runtime.onMessage.addListener(handleProgress);
+  showCancelButton();
   chrome.runtime.sendMessage({ action: 'startDownload', urls, path });
+}
+
+async function onCancelClick() {
+  document.getElementById('cancel-btn').disabled = true;
+  setStatus('キャンセルしています...');
+  await chrome.runtime.sendMessage({ action: 'cancelDownload' });
+}
+
+function showCancelButton() {
+  const btn = document.getElementById('cancel-btn');
+  btn.style.display = 'block';
+  btn.disabled = false;
+}
+
+function hideCancelButton() {
+  document.getElementById('cancel-btn').style.display = 'none';
+}
+
+function updateProgressUi(current, total, title) {
+  const pct = total ? Math.round((current / total) * 100) : 0;
+  document.getElementById('progress-wrap').style.display = 'block';
+  document.getElementById('progress-fill').style.width = pct + '%';
+  const label = title ? `「${title}」` : '';
+  setStatus(`(${current}/${total}) ${label} ダウンロード中...`);
 }
 
 async function fetchVideoUrls(info, apiKey, count) {
@@ -190,21 +225,22 @@ async function fetchVideoUrls(info, apiKey, count) {
 
 function handleProgress(message) {
   if (message.action === 'progress') {
-    const pct = Math.round((message.current / message.total) * 100);
-    document.getElementById('progress-wrap').style.display = 'block';
-    document.getElementById('progress-fill').style.width = pct + '%';
-    const title = message.title ? `「${message.title}」` : '';
-    setStatus(`(${message.current}/${message.total}) ${title} ダウンロード中...`);
+    updateProgressUi(message.current, message.total, message.title);
   } else if (message.action === 'complete') {
     document.getElementById('progress-fill').style.width = '100%';
     const failNote = message.failed > 0 ? `（失敗 ${message.failed}件）` : '';
     setStatus(`完了！ ${message.downloaded}件ダウンロードしました${failNote}`, false, true);
     document.getElementById('download-btn').disabled = false;
-    chrome.runtime.onMessage.removeListener(handleProgress);
+    hideCancelButton();
+  } else if (message.action === 'cancelled') {
+    const note = message.downloaded > 0 ? `（${message.downloaded}件ダウンロード済み）` : '';
+    setStatus(`キャンセルしました${note}`);
+    document.getElementById('download-btn').disabled = false;
+    hideCancelButton();
   } else if (message.action === 'downloadError') {
     setStatus(`エラー: ${message.error}`, true);
     document.getElementById('download-btn').disabled = false;
-    chrome.runtime.onMessage.removeListener(handleProgress);
+    hideCancelButton();
   }
 }
 


### PR DESCRIPTION
## Summary
- Downloads were driven entirely by the native C# host over a single native-messaging connection, but that connection was owned by the extension's background service worker. Manifest V3 tears down idle service workers, which silently closed the native messaging pipe (and killed the in-progress download) whenever the popup lost focus / the user switched tabs.
- `background.js` now owns all download state, keeps the service worker alive for the duration of a download via a `chrome.alarms` keep-alive, and persists state so reopening the popup rehydrates real progress instead of resetting to idle.
- `Program.cs` now runs each download batch on a background thread while the main loop keeps reading stdin, so it can receive and honor an explicit cancel request between videos.
- `popup.js` / `popup.html` add an explicit Cancel button. Downloads now only stop when the user explicitly cancels or the batch completes — not when the popup closes.

## Test plan
- [ ] Rebuild the native host exe and re-register it (native host manifest points at the compiled path)
- [ ] Load the extension in Chrome, start a multi-video (playlist/channel) download, close the popup / switch tabs, confirm the download continues and completes
- [ ] Reopen the popup mid-download and confirm it shows the current progress instead of a blank state
- [ ] Click Cancel mid-download and confirm it stops after the current video and the native host process exits cleanly
- [ ] Confirm single-video downloads and existing settings (API key, path) still work as before